### PR TITLE
fix: Unable to install OPX linux headers

### DIFF
--- a/assets/apt-preferences
+++ b/assets/apt-preferences
@@ -1,3 +1,7 @@
 Package: *
 Pin: origin ""
 Pin-Priority: 1100
+
+Package: *
+Pin: origin deb.openswitch.net
+Pin-Priority: 750


### PR DESCRIPTION
* Raise OPX package priority from 500 to 750

Signed-off-by: Tyler Heucke <tyler.heucke@dell.com>